### PR TITLE
Find the bug part 2

### DIFF
--- a/fen.go
+++ b/fen.go
@@ -158,7 +158,7 @@ func (w *Watcher) readEvents() {
 			continue
 		}
 
-		err = w.handleEvent(pevent.Object, pevent.Events, pevent.User)
+		err = w.handleEvent(&pevent)
 		if err != nil {
 			if !w.sendError(err) {
 				return
@@ -187,9 +187,10 @@ func (w *Watcher) handleDirectory(path string, stat os.FileInfo, handler func(st
 	return handler(path, stat)
 }
 
-func (w *Watcher) handleEvent(obj uint64, events int32, user *byte) error {
-	fobj := (*unix.FileObj)(unsafe.Pointer(&obj))
-	fmode := (*os.FileMode)(unsafe.Pointer(user))
+func (w *Watcher) handleEvent(event *unix.PortEvent) error {
+	fobj := (*unix.FileObj)(unsafe.Pointer(uintptr(event.Object)))
+	fmode := (*os.FileMode)(unsafe.Pointer(event.User))
+	events := event.Events
 	path := fobj.GetName()
 
 	var toSend *Event

--- a/fen.go
+++ b/fen.go
@@ -188,8 +188,11 @@ func (w *Watcher) handleDirectory(path string, stat os.FileInfo, handler func(st
 }
 
 func (w *Watcher) handleEvent(event *unix.PortEvent) error {
-	fobj := (*unix.FileObj)(unsafe.Pointer(uintptr(event.Object)))
-	user := (*os.FileMode)(unsafe.Pointer(event.User))
+	fobj, err := event.GetFileObj()
+	if err != nil  {
+		return err
+	}
+	user := (*os.FileInfo)(event.GetUser())
 	events := event.Events
 	path := fobj.GetName()
 
@@ -288,10 +291,9 @@ func (w *Watcher) associateFile(path string, stat os.FileInfo) error {
 	}
 	w.watch(path, fobj)
 
-	fmode := stat.Mode()
-	var user *os.FileMode
-	if fmode.IsDir() {
-		user = &fmode
+	var user *os.FileInfo
+	if stat.IsDir() {
+		user = &stat
 	}
 
 	mode := unix.FILE_MODIFIED | unix.FILE_ATTRIB | unix.FILE_NOFOLLOW

--- a/go.mod
+++ b/go.mod
@@ -4,4 +4,4 @@ go 1.13
 
 require golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9
 
-replace golang.org/x/sys => /home/nshalman/sys
+replace golang.org/x/sys => github.com/nshalman/sys v0.0.0-20210603013959-a87345d9d6d6

--- a/go.mod
+++ b/go.mod
@@ -3,3 +3,5 @@ module github.com/fsnotify/fsnotify
 go 1.13
 
 require golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9
+
+replace golang.org/x/sys => /home/nshalman/sys

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9 h1:L2auWcuQIvxz9xSEqzESnV/QN/gNRXNApHi3fYwl2w0=
-golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+github.com/nshalman/sys v0.0.0-20210603013959-a87345d9d6d6 h1:2yaBV3UyeuTG3grw8BZ2HeSYnyCrLeq3GcaYqc9E+uE=
+github.com/nshalman/sys v0.0.0-20210603013959-a87345d9d6d6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=


### PR DESCRIPTION
Given that https://github.com/nshalman/sys/compare/master...nshalman:fsnotify-fen passes the tests I've written so far, when compiling against that source tree, many tests pass, but sadly not all of them.
The current mystery is why...

```shell
$ git checkout rebased-solaris-fen ; go test
Switched to branch 'rebased-solaris-fen'
PASS
ok      github.com/fsnotify/fsnotify    7.965s

$ git checkout illumos-fen ; go test
Switched to branch 'illumos-fen'
--- FAIL: TestFsnotifyMultipleOperations (0.66s)
    integration_test.go:104: event received: "/tmp/fsnotify549331660": WRITE
    integration_test.go:104: event received: "/tmp/fsnotify549331660": WRITE
    integration_test.go:104: event received: "/tmp/fsnotify549331660": WRITE
    integration_test.go:167: incorrect number of create events received after 500 ms (0 vs 2)
    integration_test.go:104: event received: "/tmp/fsnotify549331660": REMOVE
--- FAIL: TestFsnotifyMultipleCreates (0.76s)
    integration_test.go:217: event received: "/tmp/fsnotify105877982": WRITE
    integration_test.go:217: event received: "/tmp/fsnotify105877982": WRITE
    integration_test.go:217: event received: "/tmp/fsnotify105877982": WRITE
    integration_test.go:294: incorrect number of create events received after 500 ms (0 vs 2)
    integration_test.go:217: event received: "/tmp/fsnotify105877982": REMOVE
--- FAIL: TestFsnotifyDirOnly (0.55s)
    integration_test.go:356: event received: "/tmp/fsnotify542869925": WRITE
    integration_test.go:356: event received: "/tmp/fsnotify542869925": WRITE
    integration_test.go:356: event received: "/tmp/fsnotify542869925/TestFsnotifyEventsExisting.testfile": REMOVE
    integration_test.go:396: incorrect number of create events received after 500 ms (0 vs 1)
--- FAIL: TestFsnotifySubDir (0.70s)
    integration_test.go:504: event received: "/tmp/fsnotify719264031": WRITE
    integration_test.go:504: event received: "/tmp/fsnotify719264031": WRITE
    integration_test.go:553: incorrect number of create events received after 500 ms (0 vs 2)
--- FAIL: TestFsnotifyRenameToCreate (0.51s)
    integration_test.go:684: event received: "/tmp/fsnotify559598761": WRITE
    integration_test.go:709: fsnotify create events have not been received after 500 ms
    integration_test.go:684: event received: "/tmp/fsnotify559598761": REMOVE
--- FAIL: TestFsnotifyFakeSymlink (0.50s)
    integration_test.go:1053: Created bogus symlink
    integration_test.go:1039: event received: "/tmp/fsnotify564860890": WRITE
    integration_test.go:1063: fsnotify other events received on the broken link
    integration_test.go:1039: event received: "/tmp/fsnotify564860890": REMOVE
--- FAIL: TestCyclicSymlink (0.50s)
    integration_test.go:1120: want at least 1 create event got 0
FAIL
exit status 1
FAIL    github.com/fsnotify/fsnotify    7.971s
```